### PR TITLE
Increase Pywikibot request timeout to 60 minutes

### DIFF
--- a/run.py
+++ b/run.py
@@ -2,6 +2,10 @@ import sys
 
 import pywikibot
 
+# Increase MediaWiki request timeout to 60 minutes so long-running queries or
+# page saves have enough time to finish without failing.
+pywikibot.config.socket_timeout = 60 * 60
+
 from bots import UserEditsBot, ActiveUsersBot, ActiveUsersLastMonthBot
 
 


### PR DESCRIPTION
## Summary
- configure Pywikibot to use a 60-minute socket timeout so that saving pages or running heavy queries has more time to finish

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c37f7ebbc8332a949424292de37f1)